### PR TITLE
fix: improve logging for failed emails

### DIFF
--- a/source/class/zx/server/email/FlushQueue.js
+++ b/source/class/zx/server/email/FlushQueue.js
@@ -28,8 +28,6 @@ qx.Class.define("zx.server.email.FlushQueue", {
         if (success) {
           this.log(`Email ${email.toUuid()} sent successfully: ${success}`);
           sentUuids.push(email.toUuid());
-        } else {
-          this.log(`ERROR: Failed to send email ${email.toUuid()}. Message: ${email.getLastErrorMessage()}`);
         }
       }
 

--- a/source/class/zx/server/email/Message.js
+++ b/source/class/zx/server/email/Message.js
@@ -193,7 +193,7 @@ qx.Class.define("zx.server.email.Message", {
       let attachmentsData = [{ data: htmlBody, alternative: true }];
       log("Before getting attachments");
       if (this.getAttachments()) {
-        const mime = (await import("mime")).default;
+        let mime = (await import("mime")).default;
         this.getAttachments().forEach(attachment => {
           let filename = attachment.getPath();
           let stream = fs.createReadStream(filename);

--- a/source/class/zx/server/email/Message.js
+++ b/source/class/zx/server/email/Message.js
@@ -193,7 +193,7 @@ qx.Class.define("zx.server.email.Message", {
       let attachmentsData = [{ data: htmlBody, alternative: true }];
       log("Before getting attachments");
       if (this.getAttachments()) {
-        let mime = (await import("mime")).default;
+        const mime = (await import("mime")).default;
         this.getAttachments().forEach(attachment => {
           let filename = attachment.getPath();
           let stream = fs.createReadStream(filename);
@@ -250,7 +250,7 @@ qx.Class.define("zx.server.email.Message", {
           let server = zx.server.Standalone.getInstance();
           emailJsMessage = await server.findOneObjectByType(zx.server.email.Message, { _uuid: this.toUuid() });
         }
-        log(`Error sending email with UUID: ${this.toUuid()}. Stack: ${err?.stack ?? "(no stack trace)"}`);
+        this.error(`Error sending email with UUID: ${this.toUuid()}. Stack: ${err?.stack ?? "(no stack trace)"}`);
         this.setLastErrorMessage(err ? err.message : "Unknown error when sending email");
         await this.save();
       }


### PR DESCRIPTION
This fixes an issue when an email has failed to send, the error was swallowed and nothing was printed out in the logs.