### PR TITLE
fix: make execution context null again after we finished grouping the…

### DIFF
--- a/source/class/zx/reports/CollatingIterator.js
+++ b/source/class/zx/reports/CollatingIterator.js
@@ -464,6 +464,7 @@ qx.Class.define("zx.reports.CollatingIterator", {
           }
         }
       }
+      this.__executionContext = null;
       return <div>{content}</div>;
     },
 

--- a/source/class/zx/reports/ReportRunner.js
+++ b/source/class/zx/reports/ReportRunner.js
@@ -19,6 +19,8 @@
  * Runs a report, using the given iterator to generate the report, adds loading
  * message while the report is being generated, and then replaces the loading
  * message with the report
+ *
+ * @ignore(Blob)
  */
 qx.Class.define("zx.reports.ReportRunner", {
   extend: qx.core.Object,


### PR DESCRIPTION
… data