### PR TITLE
fix: debounce flush after property change in NetworkEndpoint (client only)

### DIFF
--- a/source/class/zx/io/remote/NetworkEndpoint.js
+++ b/source/class/zx/io/remote/NetworkEndpoint.js
@@ -38,6 +38,10 @@ qx.Class.define("zx.io.remote.NetworkEndpoint", {
     if (qx.core.Environment.get("zx.io.remote.NetworkEndpoint.server") === undefined) {
       throw new Error("You must set `zx.io.remote.NetworkEndpoint.server` as an environment variable in `compile.json` and recompile with `--clean`");
     }
+
+    if (!qx.core.Environment.get("zx.io.remote.NetworkEndpoint.server")) {
+      this.__flushDebounce = new zx.utils.Debounce(() => this.flush(), 5);
+    }
   },
 
   destruct() {
@@ -85,6 +89,9 @@ qx.Class.define("zx.io.remote.NetworkEndpoint", {
 
     /** @type{Map} list of property changes that are queued for delivery */
     __propertyChangeStore: null,
+
+    /** @type{zx.utils.Debounce?} debounce for flushing property changes on the client */
+    __flushDebounce: null,
 
     /**
      * Whether the end point is open
@@ -351,6 +358,7 @@ qx.Class.define("zx.io.remote.NetworkEndpoint", {
         store = this.__propertyChangeStore[uuid] = {};
       }
       io.storeChange(store, propertyName, changeType, value);
+      this.__flushDebounce?.run();
     },
 
     /**


### PR DESCRIPTION
## Problem

Property changes queued in `__propertyChangeStore` (via `onWatchedPropertySerialized`) were only flushed when the next `callRemoteMethod()` ran. This caused 10+ second delays for remote events triggered solely by property changes (e.g. `map.put()` via `MConfiguration.setValue()`).

**Symptom:** `vzaweb.test.data.client.Configuration:testChangeValueEventFiredOnSet` timed out after 10 seconds, because the `changeValue` remote event was only delivered when a later test triggered a remote method call.

## Fix

In `construct()`, create a `zx.utils.Debounce` (5 ms) on the **client** only (`!zx.io.remote.NetworkEndpoint.server`). `onWatchedPropertySerialized()` calls `this.__flushDebounce?.run()` after queuing each change, so rapid changes are batched into one flush packet.

The server guard ensures no behaviour change on the server side, where `_receivePacketsImpl` already handles flushing.

## Changes

- `source/class/zx/io/remote/NetworkEndpoint.js` — add `__flushDebounce` member + debounce init in `construct()` + trigger in `onWatchedPropertySerialized()`
