### PR TITLE
fix: enable __flushDebounce on the server side

### DIFF
--- a/source/class/zx/io/remote/NetworkEndpoint.js
+++ b/source/class/zx/io/remote/NetworkEndpoint.js
@@ -34,9 +34,7 @@ qx.Class.define("zx.io.remote.NetworkEndpoint", {
     this.__uuid = uuid || this.toUuid();
     this.__receiveQueue = new zx.utils.Queue(packets => this._receivePacketsImpl(packets));
 
-    if (!qx.core.Environment.get("zx.io.remote.NetworkEndpoint.server")) {
-      this.__flushDebounce = new qx.util.Debounce(() => this.flush(), 5).set({ onPending: "ignore" });
-    }
+    this.__flushDebounce = new qx.util.Debounce(() => this.flush(), 5).set({ onPending: "ignore" });
 
     zx.io.remote.NetworkEndpoint.__allEndpoints[this.__uuid] = this;
     if (qx.core.Environment.get("zx.io.remote.NetworkEndpoint.server") === undefined) {


### PR DESCRIPTION
Problem
zx.io.remote.NetworkEndpoint.__flushDebounce is only created on the
client side. Server-side property mutations triggered outside the RPC
pipeline (pg_notify handlers, watchdogs, cron jobs, periodic state
refreshes) are never pushed to clients, because the
optional-chaining call this.__flushDebounce?.trigger() in
onWatchedPropertySerialized resolves to a silent no-op on servers.

The bug only surfaces when something other than an incoming packet
mutates server-side properties. As long as every change is the
consequence of an RPC call, _receivePacketsImpl flushes
synchronously at the end of packet handling and everything works.

Fix
Drop the client-only guard. The server gets the same 5 ms coalescing
the client has had since forever.

Validation
Verified downstream: a pg_notify listener that mutates a watched
configuration object now propagates to the browser within ~10-50 ms.
DELETE path verified the same way. RPC-driven mutations are
unaffected.

Risk
Very low. The debounce existed in production on the client side;
behaviour is identical, just enabled on a second compile target.
The queue is already drained when the debounce would have fired
during RPC processing, so no double-flush.

Happy to add a regression test if desired — left out because the fix
is a single line and the root cause is well-understood.