### PR TITLE
feat: add WebSocket transport for zx.io.remote

### DIFF
--- a/compile.json
+++ b/compile.json
@@ -146,6 +146,24 @@
       "exclude": ["qx.bom.Selector"],
       "type": "node",
       "class": "zx.demo.io.api.srv.ServerApp"
+    },
+    {
+      "title": "Tests - WebSocket peer server",
+      "description": "Node peer app: Fastify+WebSocket server publishing a Person fixture; pairs with peer-ws-client",
+      "class": "zx.test.io.remote.RemoteWebSocketServer",
+      "type": "node",
+      "name": "peer-ws-server",
+      "exclude": ["qx.ui.*"],
+      "group": ["tests"]
+    },
+    {
+      "title": "Tests - WebSocket peer client",
+      "description": "Node peer app: connects to peer-ws-server via WebSocket and reads the Person fixture",
+      "class": "zx.test.io.remote.DemoRemoteWebSocketClient",
+      "type": "node",
+      "name": "peer-ws-client",
+      "exclude": ["qx.ui.*"],
+      "group": ["tests"]
     }
   ],
   "sass": {

--- a/package.json
+++ b/package.json
@@ -85,5 +85,13 @@
     "@types/express": "^5.0.0",
     "cheerio": "^1.0.0-rc.9",
     "globby": "^10.0.2"
+  },
+  "peerDependencies": {
+    "@fastify/websocket": "^11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@fastify/websocket": {
+      "optional": true
+    }
   }
 }

--- a/source/class/zx/io/remote/WebSocketClientEndpoint.js
+++ b/source/class/zx/io/remote/WebSocketClientEndpoint.js
@@ -1,0 +1,76 @@
+/* ************************************************************************
+ *
+ *  Zen [and the art of] CMS
+ *
+ *  https://zenesis.com
+ *
+ *  License: MIT (see LICENSE in project root)
+ *
+ * ************************************************************************ */
+
+/**
+ * Client-side WebSocket endpoint, parallel to BrowserXhrEndpoint.
+ *
+ * @ignore(WebSocket)
+ */
+qx.Class.define("zx.io.remote.WebSocketClientEndpoint", {
+  extend: zx.io.remote.NetworkEndpoint,
+
+  /**
+   * @param {String?} url WebSocket URL, defaults to "/zx-remote-ws"
+   */
+  construct(url) {
+    super();
+    this.__url = url ?? "/zx-remote-ws";
+  },
+
+  members: {
+    _supportsPushPackets: true,
+
+    /** @type {WebSocket} */
+    __ws: null,
+    /** @type {String} */
+    __url: null,
+
+    /** @override */
+    async _startup() {
+      let sep = this.__url.indexOf("?") === -1 ? "?" : "&";
+      let url = this.__url + sep + "uuid=" + this.getUuid() + "&_t=" + Date.now();
+      this.__ws = new WebSocket(url);
+
+      this.__ws.onmessage = async evt => {
+        let packets = zx.utils.Json.parseJson(evt.data);
+        let responses = await this._receivePackets(null, null, packets);
+        if (responses && responses.length) {
+          this._flushImpl(responses);
+        }
+      };
+
+      this.__ws.onclose = () => {
+        if (this.isOpen()) {
+          this.close();
+        }
+      };
+
+      await new Promise((resolve, reject) => {
+        this.__ws.onopen = resolve;
+        this.__ws.onerror = reject;
+      });
+    },
+
+    /** @override */
+    async _shutdown() {
+      if (this.__ws) {
+        this.__ws.close();
+        this.__ws = null;
+      }
+    },
+
+    /** @override */
+    _flushImpl(queuedPackets) {
+      if (this.__ws?.readyState === 1 /* WebSocket.OPEN */) {
+        this.__ws.send(zx.utils.Json.stringifyJson(queuedPackets));
+      }
+    }
+  }
+});

--- a/source/class/zx/io/remote/WebSocketServerEndpoint.js
+++ b/source/class/zx/io/remote/WebSocketServerEndpoint.js
@@ -1,0 +1,94 @@
+/* ************************************************************************
+ *
+ *  Zen [and the art of] CMS
+ *
+ *  https://zenesis.com
+ *
+ *  License: MIT (see LICENSE in project root)
+ *
+ * ************************************************************************ */
+
+/**
+ * Server-side WebSocket endpoint. One per connection.
+ */
+qx.Class.define("zx.io.remote.WebSocketServerEndpoint", {
+  extend: zx.io.remote.NetworkEndpoint,
+
+  /**
+   * @param {Object} socket WebSocket connection from @fastify/websocket
+   * @param {String?} uuid UUID to use; if omitted a fresh one is generated
+   */
+  construct(socket, uuid) {
+    super(uuid);
+    this.__socket = socket;
+  },
+
+  events: {
+    /**
+     * Fires before incoming packets are processed. Listeners may set
+     * evt.getData().wrapper to an `async fn => ...` wrapper that the
+     * endpoint will await around `_receivePackets`. Useful for
+     * request-scoped context (auth, tenant, db transaction).
+     */
+    beforeReceive: "qx.event.type.Data"
+  },
+
+  members: {
+    _supportsPushPackets: true,
+
+    /** @type {Object} */
+    __socket: null,
+
+    /** @override */
+    getUniqueIndexId() {
+      return "WS:" + this.getUuid();
+    },
+
+    /** @override */
+    _flushImpl(queuedPackets) {
+      if (this.__socket?.readyState === 1 /* OPEN */) {
+        this.__socket.send(zx.utils.Json.stringifyJson(queuedPackets));
+      }
+    },
+
+    /**
+     * Called by the listener for every inbound message frame.
+     * @param {String} data raw JSON
+     */
+    async receiveFromClient(data) {
+      let packets;
+      try {
+        packets = zx.utils.Json.parseJson(data);
+      } catch (ex) {
+        qx.log.Logger.error(this, "Invalid JSON received", ex);
+        return;
+      }
+
+      let evtData = { packets, wrapper: null };
+      this.fireDataEvent("beforeReceive", evtData);
+      let wrapper = evtData.wrapper ?? (fn => fn());
+
+      try {
+        await wrapper(async () => {
+          let responses = await this._receivePackets(null, null, packets);
+          if (responses && responses.length) {
+            this._flushImpl(responses);
+          }
+        });
+      } catch (ex) {
+        qx.log.Logger.error(this, "Error processing message", ex);
+        let errors = packets
+          .filter(p => p.type === "callMethod")
+          .map(p => ({
+            type: "return",
+            originPacketId: p.packetId,
+            methodName: p.methodName,
+            exception: { message: ex.message }
+          }));
+        if (errors.length) {
+          this._flushImpl(errors);
+        }
+      }
+    }
+  }
+});

--- a/source/class/zx/io/remote/WebSocketServerListener.js
+++ b/source/class/zx/io/remote/WebSocketServerListener.js
@@ -1,0 +1,62 @@
+/* ************************************************************************
+ *
+ *  Zen [and the art of] CMS
+ *
+ *  https://zenesis.com
+ *
+ *  License: MIT (see LICENSE in project root)
+ *
+ * ************************************************************************ */
+
+/**
+ * Fastify-WebSocket listener; one per app instance. Pairs with
+ * WebSocketServerEndpoint per connection.
+ */
+qx.Class.define("zx.io.remote.WebSocketServerListener", {
+  extend: qx.core.Object,
+
+  /**
+   * @param {zx.io.remote.NetworkController} controller
+   * @param {import("fastify").FastifyInstance} app
+   * @param {Object?} options
+   * @param {String?} options.route defaults to "/zx-remote-ws"
+   */
+  construct(controller, app, options) {
+    super();
+    this.__controller = controller;
+    let route = options?.route ?? "/zx-remote-ws";
+    app.get(route, { websocket: true }, (socket, req) =>
+      this.__handleConnection(socket, req)
+    );
+  },
+
+  events: {
+    /**
+     * Fires after a new endpoint has been created and added to the
+     * controller. Event data: { endpoint, request }.
+     */
+    addEndpoint: "qx.event.type.Data"
+  },
+
+  members: {
+    /** @type {zx.io.remote.NetworkController} */
+    __controller: null,
+
+    __handleConnection(socket, req) {
+      let uuid = req?.query?.uuid ?? null;
+      let endpoint = new zx.io.remote.WebSocketServerEndpoint(socket, uuid);
+
+      socket.on("message", async data => {
+        await endpoint.receiveFromClient(data.toString());
+      });
+      socket.on("close", () => {
+        this.__controller.removeEndpoint(endpoint);
+        endpoint.close();
+      });
+
+      this.__controller.addEndpoint(endpoint);
+      endpoint.open();
+      this.fireDataEvent("addEndpoint", { endpoint, request: req });
+    }
+  }
+});

--- a/source/class/zx/test/NodeUnitTestsApp.js
+++ b/source/class/zx/test/NodeUnitTestsApp.js
@@ -38,6 +38,7 @@ qx.Class.define("zx.test.NodeUnitTestsApp", {
       zx.test.TestRunner.runAll(zx.test.io.persistence.TestImportExport);
       zx.test.TestRunner.runAll(zx.test.io.persistence.TestNedbDatabase);
       zx.test.TestRunner.runAll(zx.test.io.remote.TestPropertyChanges);
+      zx.test.TestRunner.runAll(zx.test.io.remote.TestWebSocketEndpoints);
       zx.test.TestRunner.runAll(zx.test.cms.TestTemplates, ["testCms"]);
     }
   }

--- a/source/class/zx/test/io/remote/DemoRemoteWebSocketClient.js
+++ b/source/class/zx/test/io/remote/DemoRemoteWebSocketClient.js
@@ -1,0 +1,45 @@
+/* ************************************************************************
+ *
+ *  Zen [and the art of] CMS
+ *
+ *  https://zenesis.com
+ *
+ *  License: MIT (see LICENSE in project root)
+ *
+ * ************************************************************************ */
+
+/* eslint-env node */
+
+/**
+ * Node peer app: connects to a RemoteWebSocketServer instance specified via
+ * the `ZX_TEST_WS_PORT` environment variable, fetches the Person fixture and
+ * prints `{ "name": "<value>" }` to stdout before exiting. Pairs with the
+ * RemoteWebSocketServer peer app for end-to-end WebSocket transport tests.
+ */
+qx.Class.define("zx.test.io.remote.DemoRemoteWebSocketClient", {
+  extend: qx.application.Basic,
+
+  members: {
+    async main() {
+      let port = process.env.ZX_TEST_WS_PORT;
+      if (!port) {
+        process.stderr.write("ZX_TEST_WS_PORT not set\n");
+        process.exit(2);
+        return;
+      }
+
+      let controller = new zx.io.remote.NetworkController();
+      let endpoint = new zx.io.remote.WebSocketClientEndpoint(
+        `ws://127.0.0.1:${port}/zx-remote-ws`
+      );
+      controller.addEndpoint(endpoint);
+      await endpoint.open();
+
+      let person = await controller.getUriMappingAsync("zx.test.io.remote.Person");
+      process.stdout.write(JSON.stringify({ name: person.getName() }) + "\n");
+
+      await endpoint.close();
+      process.exit(0);
+    }
+  }
+});

--- a/source/class/zx/test/io/remote/RemoteWebSocketServer.js
+++ b/source/class/zx/test/io/remote/RemoteWebSocketServer.js
@@ -1,0 +1,45 @@
+/* ************************************************************************
+ *
+ *  Zen [and the art of] CMS
+ *
+ *  https://zenesis.com
+ *
+ *  License: MIT (see LICENSE in project root)
+ *
+ * ************************************************************************ */
+
+/* eslint-env node */
+
+/**
+ * Node peer app: starts a Fastify server with the @fastify/websocket plugin
+ * and exposes a single Person fixture via zx.io.remote over WebSocket. On
+ * startup the actual port (port: 0 picks a free one) is printed as a single
+ * JSON line `{ "port": <n> }` so a parent test process can spawn this app
+ * and pair it with a matching client peer.
+ */
+qx.Class.define("zx.test.io.remote.RemoteWebSocketServer", {
+  extend: qx.application.Basic,
+
+  members: {
+    async main() {
+      const fastify = require("fastify");
+      const fastifyWebsocket = require("@fastify/websocket");
+
+      let app = fastify({ logger: false });
+      await app.register(fastifyWebsocket);
+
+      let controller = new zx.io.remote.NetworkController();
+      let listener = new zx.io.remote.WebSocketServerListener(controller, app);
+
+      let person = new zx.test.io.remote.Person("Alice").set({ age: 30 });
+      listener.addListener("addEndpoint", evt => {
+        let endpoint = evt.getData().endpoint;
+        endpoint.putUriMapping("zx.test.io.remote.Person", person);
+      });
+
+      await app.listen({ port: 0, host: "127.0.0.1" });
+      let address = app.server.address();
+      process.stdout.write(JSON.stringify({ port: address.port }) + "\n");
+    }
+  }
+});

--- a/source/class/zx/test/io/remote/TestWebSocketEndpoints.js
+++ b/source/class/zx/test/io/remote/TestWebSocketEndpoints.js
@@ -1,0 +1,150 @@
+/* ************************************************************************
+ *
+ *  Zen [and the art of] CMS
+ *
+ *  https://zenesis.com
+ *
+ *  License: MIT (see LICENSE in project root)
+ *
+ * ************************************************************************ */
+
+/* eslint-env node */
+
+/**
+ * Unit tests for the WebSocket transport in zx.io.remote.
+ */
+qx.Class.define("zx.test.io.remote.TestWebSocketEndpoints", {
+  extend: qx.dev.unit.TestCase,
+
+  members: {
+    async testPeerRoundtrip() {
+      const { spawn } = require("child_process");
+
+      let serverProc = spawn(
+        "npx",
+        ["qx", "run", "--app=peer-ws-server"],
+        { shell: true, env: process.env }
+      );
+
+      let port = await new Promise((resolve, reject) => {
+        let buf = "";
+        let done = false;
+        let timeout = setTimeout(() => {
+          if (!done) {
+            done = true;
+            reject(new Error("Timeout waiting for server port"));
+          }
+        }, 30000);
+        serverProc.stdout.on("data", chunk => {
+          buf += chunk.toString();
+          let nl = buf.indexOf("\n");
+          while (nl !== -1) {
+            let line = buf.substring(0, nl).trim();
+            buf = buf.substring(nl + 1);
+            if (line.startsWith("{")) {
+              try {
+                let parsed = JSON.parse(line);
+                if (parsed.port && !done) {
+                  done = true;
+                  clearTimeout(timeout);
+                  resolve(parsed.port);
+                  return;
+                }
+              } catch (ex) {
+                // not the line we wanted, keep going
+              }
+            }
+            nl = buf.indexOf("\n");
+          }
+        });
+        serverProc.on("exit", code => {
+          if (!done) {
+            done = true;
+            clearTimeout(timeout);
+            reject(new Error("Server exited prematurely with code " + code));
+          }
+        });
+      });
+
+      try {
+        let clientOut = await new Promise((resolve, reject) => {
+          let env = Object.assign({}, process.env, { ZX_TEST_WS_PORT: String(port) });
+          let clientProc = spawn(
+            "npx",
+            ["qx", "run", "--app=peer-ws-client"],
+            { shell: true, env }
+          );
+          let buf = "";
+          clientProc.stdout.on("data", chunk => (buf += chunk.toString()));
+          clientProc.on("exit", code => {
+            if (code !== 0) {
+              reject(new Error("Client exited with code " + code));
+            } else {
+              resolve(buf);
+            }
+          });
+        });
+
+        let nameLine = clientOut
+          .split("\n")
+          .map(l => l.trim())
+          .filter(l => l.startsWith("{") && l.includes("name"))
+          .pop();
+        this.assertNotNull(nameLine, "no name line in client output");
+        let parsed = JSON.parse(nameLine);
+        this.assertEquals("Alice", parsed.name);
+      } finally {
+        serverProc.kill();
+      }
+    },
+
+    async testBeforeReceiveHook() {
+      let order = [];
+      let socket = { readyState: 1, send() {} };
+      let endpoint = new zx.io.remote.WebSocketServerEndpoint(socket);
+
+      endpoint._receivePackets = async () => {
+        order.push("receive");
+        return [];
+      };
+
+      endpoint.addListener("beforeReceive", evt => {
+        order.push("before");
+        let data = evt.getData();
+        data.wrapper = async fn => {
+          await fn();
+          order.push("after");
+        };
+      });
+
+      await endpoint.receiveFromClient("[]");
+
+      this.assertEquals("before,receive,after", order.join(","));
+    },
+
+    async testExceptionProducesReturnPackets() {
+      let sent = [];
+      let socket = {
+        readyState: 1,
+        send(data) {
+          sent.push(data);
+        }
+      };
+      let endpoint = new zx.io.remote.WebSocketServerEndpoint(socket);
+
+      endpoint._receivePackets = async () => {
+        throw new Error("boom");
+      };
+
+      let inbound = [{ type: "callMethod", packetId: 1, methodName: "doStuff" }];
+      await endpoint.receiveFromClient(JSON.stringify(inbound));
+
+      this.assertEquals(1, sent.length);
+      let packets = JSON.parse(sent[0]);
+      this.assertEquals(1, packets.length);
+      this.assertEquals("return", packets[0].type);
+      this.assertEquals(1, packets[0].originPacketId);
+      this.assertEquals("boom", packets[0].exception.message);
+    }
+  }
+});


### PR DESCRIPTION
Summary
Adds a WebSocket transport pair to zx.io.remote, mirroring the
existing XHR pair (FastifyXhrListener / FastifyXhrEndpoint and
BrowserXhrEndpoint). New classes:

zx.io.remote.WebSocketClientEndpoint — browser
zx.io.remote.WebSocketServerEndpoint — Node, one per connection
zx.io.remote.WebSocketServerListener — Fastify plugin wrapper
Why
@fastify/websocket is added as an optional peer-dep so existing
deployments are unaffected. Property push works today via the XHR
transport's batched flush, but is request-driven; this contrib adds a
true server-initiated push channel that any deployment can opt into.

Hook for request-scoped context
WebSocketServerEndpoint fires beforeReceive with {packets, wrapper} before processing each inbound message. Listeners can
install an async wrapper, e.g. for a database/auth/tenant scope:

endpoint.addListener("beforeReceive", evt => {
  evt.getData().wrapper = fn => myAuth.run(req.user, fn);
});
Default wrapper is a passthrough.

Tests
Peer-style end-to-end test (RemoteWebSocketServer +
DemoRemoteWebSocketClient as Node peer apps in compile.json)
Unit coverage for the beforeReceive hook ordering
Unit coverage for exception-to-return-packet conversion
TestWebSocketEndpoints registered in NodeUnitTestsApp
Out of scope
Reconnect/backoff strategy on the client (application concern)
Authentication / tenant routing (handled via beforeReceive hook)
Long-polling fallback over XHR (separate contrib if useful)
Binary frames / MessagePack
