### PR TITLE
Fix remote event annotation lookup in NetworkEndpoint

### DIFF
--- a/source/class/zx/io/remote/NetworkEndpoint.js
+++ b/source/class/zx/io/remote/NetworkEndpoint.js
@@ -1070,11 +1070,10 @@ qx.Class.define("zx.io.remote.NetworkEndpoint", {
       let result = [];
       let walk = clazz;
       while (walk) {
-        let evts = walk.$$events;
-        if (evts) {
-          for (let name of Object.keys(evts)) {
-            let annos = qx.Annotation.getMember(walk, name, zx.io.remote.anno.Event);
-            if (annos && annos.length) {
+        let annoEvents = walk.$$annotations && walk.$$annotations.events;
+        if (annoEvents) {
+          for (let [name, annos] of Object.entries(annoEvents)) {
+            if (annos.some(a => a instanceof zx.io.remote.anno.Event)) {
               if (!result.includes(name)) {
                 result.push(name);
               }


### PR DESCRIPTION
## Summary

`zx.io.remote.NetworkEndpoint.__getRemoteEventNames` used
`qx.Annotation.getMember`, which looks up annotations under
`$$annotations.members`. Event annotations declared as
`events: { "@evt": ... }` are stored by qooxdoo under
`$$annotations.events` (via `qx.Class.addEvents` →
`__attachAnno(clazz, "events", ...)`), so the lookup never matched.

Result: `__attachRemoteEventListeners` saw an empty list, no listeners
were registered, and `zx:remoteEvent` packets were never pushed to
clients — Server→Client event propagation was effectively broken.

## Fix

Walk the class hierarchy directly through `$$annotations.events` and
filter for `zx.io.remote.anno.Event` instances. Caching and iteration
order are preserved.